### PR TITLE
Command line response to `desk`

### DIFF
--- a/desk/main.py
+++ b/desk/main.py
@@ -1,7 +1,7 @@
 import argparse
 import inspect
 import ipdb
-import os
+import sys
 
 from desk import console_commands
 
@@ -34,7 +34,8 @@ def main():
             func(**funcargs)
             break  # drop out immediately, which skips the "else" below
     else:
-        os.system('desk --help')
+        parser.print_help()
+        sys.exit(0)
 
 if __name__ == "__main__":
     main()

--- a/desk/main.py
+++ b/desk/main.py
@@ -1,6 +1,7 @@
 import argparse
 import inspect
-import pdb
+import ipdb
+import os
 
 from desk import console_commands
 
@@ -33,8 +34,7 @@ def main():
             func(**funcargs)
             break  # drop out immediately, which skips the "else" below
     else:
-        assert False, "Invalid subparser! This should be impossible..."
-
+        os.system('desk --help')
 
 if __name__ == "__main__":
     main()

--- a/desk/main.py
+++ b/desk/main.py
@@ -1,6 +1,5 @@
 import argparse
 import inspect
-import ipdb
 import sys
 
 from desk import console_commands


### PR DESCRIPTION
Upon entering only `desk`, the command line will now return the `desk --help'` response.