### PR TITLE
Corrected GRAMS scaling

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,8 +6,8 @@ name: Python package
 on:
   push:
     branches: [ main, development]
-  pull_request:
-    branches: [ main ]
+  # pull_request:
+  #   branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,8 +33,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip3 install flake8 pytest
-          pip3 install numpy==1.18.0
-          pip3 install -r requirements.txt
+          pip3 install numpy
+          pip3 install setuptools==49.6.0
+          pip3 install --no-cache-dir -r requirements.txt
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
 
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
     name: ${{ matrix.os }} python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,16 +1,13 @@
 name: desk
 
 channels:
-    - conda-forge
+    - astropy
 
 dependencies:
     - astropy
-    - scipy
-    - numpy
     - Cython
     - matplotlib
     - sphinx
     - sphinx-astropy
     - sphinx_automodapi
     - Pillow
-    - pip

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -1,13 +1,16 @@
 name: desk
 
 channels:
-    - astropy
+    - conda-forge
 
 dependencies:
     - astropy
+    - scipy
+    - numpy
     - Cython
     - matplotlib
     - sphinx
     - sphinx-astropy
     - sphinx_automodapi
     - Pillow
+    - pip

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The DESK is an SED-fitting python package for fitting data from evolved stars (p
 **Output**: A csv files with the best fit model and corresponding stellar parameters, as well as an optional figure of the fit SED.
 
 **Available model grids**:
-Several grids are **already available** upon installation. A range of other model grids, including 2D [GRAMS](https://2dust.stsci.edu/grams_models.cgi) model grids based on the [2DUST](https://2dust.stsci.edu/index.cgi) code, and state-of-the-art dust-growth models by [Nanni et al. (2019)](https://ui.adsabs.harvard.edu/abs/2019MNRAS.487..502N/abstract), are downloaded automatically and used when selected. Descriptions of the [model grids](https://dusty-evolved-star-kit.readthedocs.io/en/latest/grids.html) can be found in the documentation.
+Several grids are **already available** upon installation. A range of other model grids, including 2D [GRAMS](https://ui.adsabs.harvard.edu/abs/2011ApJ...728...93S/abstract) model grids based on the [2DUST](https://ui.adsabs.harvard.edu/abs/2003ApJ...586.1338U/abstract) code, and state-of-the-art dust-growth models by [Nanni et al. (2019)](https://ui.adsabs.harvard.edu/abs/2019MNRAS.487..502N/abstract), are downloaded automatically and used when selected. Descriptions of the [model grids](https://dusty-evolved-star-kit.readthedocs.io/en/latest/grids.html) can be found in the documentation.
 
 
 A module for creating your own [DUSTY](https://github.com/ivezic/dusty) grid is under development, but for now, please email me ([Dr. Steven Goldman](http://www.stsci.edu/~sgoldman/)) directly for potential grid requests or for help with the package.

--- a/desk/__init__.py
+++ b/desk/__init__.py
@@ -10,7 +10,7 @@
 __author__ = "Steven R. Goldman"
 __email__ = "sgoldman@stsci.edu"
 __title__ = "DESK"
-__version__ = "1.8.2"
+__version__ = "1.8.3"
 __repository__ = "https://github.com/s-goldman/Dusty-Evolved-Star-Kit"
 __date_published = "2021-04-13"
 __licence__ = "BSD"

--- a/desk/console_commands.py
+++ b/desk/console_commands.py
@@ -222,10 +222,13 @@ def fit(
 
     # Fitting
     print("\nFit parameters\n--------------")
-    print("Grid: \t\t" + grid)
-    print("Distance: \t" + str(distance) + " kpc")
-    print("Grid density: \t" + str(n))
-    print("Cores: \t\t" + str(n_cores))
+    print("Grid:\t\t" + grid)
+    print("Distance:\t" + str(distance) + " kpc")
+    if fit_params.grid in config.external_grids:
+        print("Grid density:\t" + str(n) + " (ignored as it is an external grids)")
+    else:
+        print("Grid density:\t" + str(n))
+    print("# of cores:\t" + str(n_cores))
 
     if n_cores == 1:
         # Single-core fitting

--- a/desk/console_commands.py
+++ b/desk/console_commands.py
@@ -43,6 +43,7 @@ def sed(
     source_filename="fitting_results.csv",
     dest_path=".",
     save_name="output_sed.png",
+    flux="Wm2",
 ):
     """Creates single SED figure of all fit SEDs using
     the 'fitting_results.csv' file.
@@ -57,16 +58,21 @@ def sed(
         Path to save figure.
     save_name : str
         Figure filename to be saved.
-
+    flux: str
+        flux type (Wm2 or Jy)
     Returns
     -------
     png
         SED figure with data in blue and model in black.
     """
-    plotting_seds.create_fig(source_path, source_filename, dest_path, save_name)
+    plotting_seds.create_fig(
+        source_path, source_filename, dest_path, save_name, flux=flux
+    )
 
 
-def sed_indiv(source_path=".", source_filename="fitting_results.csv", dest_path="."):
+def sed_indiv(
+    source_path=".", source_filename="fitting_results.csv", dest_path=".", flux="Wm2"
+):
     """Creates individual SED figures for all fit SEDs using
     the 'fitting_results.csv' file.
 
@@ -80,13 +86,14 @@ def sed_indiv(source_path=".", source_filename="fitting_results.csv", dest_path=
         Path to save figure.
     save_name : str
         Figure filename to be saved.
-
+    flux: str
+        flux type (Wm2 or Jy)
     Returns
     -------
     png
         SED figure with data in blue and model in black.
     """
-    plotting_seds.single_figures(source_path, source_filename, dest_path)
+    plotting_seds.single_figures(source_path, source_filename, dest_path, flux=flux)
 
 
 def save_model(grid_name, luminosity, teff, tinner, tau, distance_in_kpc):

--- a/desk/fitting/dusty_fit.py
+++ b/desk/fitting/dusty_fit.py
@@ -84,7 +84,12 @@ def fit_single_source(source_number, fit_params):
     # creates results file
     with open("fitting_results.csv", "a") as f:
         writer = csv.writer(f, delimiter=",", lineterminator="\n")
-        writer.writerow([target_name] + [str(x) for x in out[0]] + [source_file_name])
+        writer.writerow(
+            [target_name]
+            + [str(x) for x in out[0]]
+            + [source_file_name]
+            + [fit_params.distance]
+        )
         f.close()
 
     # printed output

--- a/desk/outputs/plotting_seds.py
+++ b/desk/outputs/plotting_seds.py
@@ -1,5 +1,6 @@
 import sys
 import math
+import ipdb
 import seaborn as sns
 import astropy.units as u
 import matplotlib.pyplot as plt
@@ -113,20 +114,11 @@ def get_model_and_data_for_plotting(counter, target, source_path, source_filenam
 
     x_model = x_model[np.where(y_model != 0)]
     y_model = y_model[np.where(y_model != 0)]
-
-    if fnmatch(input_file["grid_name"][0], "grams*"):
-        y_model = y_model * u.Jy
-        y_model = y_model.to(
-            u.W / (u.m * u.m), equivalencies=u.spectral_density(x_model * u.um)
-        )
-
-    else:
-        y_model = y_model * u.W / (u.m * u.m)
-        y_model = y_model * np.power(10, input_file[counter]["norm"])
+    y_model = y_model * np.power(10, input_file[counter]["norm"])
 
     # logscale
     x_model = np.log10(x_model)
-    y_model = np.log10(y_model.value)
+    y_model = np.log10(y_model)
     x_data = np.log10(x_data)
     y_data = np.log10(y_data)
     return x_model, y_model, x_data, y_data

--- a/desk/outputs/plotting_seds.py
+++ b/desk/outputs/plotting_seds.py
@@ -1,5 +1,4 @@
 import sys
-import ipdb
 import math
 import seaborn as sns
 import astropy.units as u

--- a/desk/outputs/plotting_seds.py
+++ b/desk/outputs/plotting_seds.py
@@ -1,6 +1,5 @@
 import sys
 import math
-import ipdb
 import seaborn as sns
 import astropy.units as u
 import matplotlib.pyplot as plt

--- a/desk/set_up/create_output_files.py
+++ b/desk/set_up/create_output_files.py
@@ -28,6 +28,9 @@ def make_output_files_dusty(fit_params):
 
     with open("fitting_results.csv", "w") as f:
         f.write(
-            "source, " + (", ".join(fit_params.full_outputs.colnames)) + ", file_name\n"
+            "source, "
+            + (", ".join(fit_params.full_outputs.colnames))
+            + ", file_name"
+            + ", distance\n"
         )
         f.close()

--- a/desk/set_up/full_grid.py
+++ b/desk/set_up/full_grid.py
@@ -66,9 +66,11 @@ def retrieve(full_grid_params):
 
     if full_grid_params.grid in config.external_grids:
         full_outputs, full_model_grid = scale_external.scale_by_distance(
+            full_grid_params.grid,
             full_grid_params.grid_outputs,
             full_grid_params.grid_dusty,
             full_grid_params.scaling_factor_flux_to_Lsun,
+            full_grid_params.distance,
         )
     else:
         # scale DUSTY outputs

--- a/desk/set_up/get_models.py
+++ b/desk/set_up/get_models.py
@@ -3,6 +3,7 @@ import os
 import ipdb
 import numpy as np
 import h5py
+from fnmatch import fnmatch
 from shutil import copyfile
 from astropy.table import Table, Column
 from astropy.utils.data import download_file

--- a/desk/set_up/get_models.py
+++ b/desk/set_up/get_models.py
@@ -3,7 +3,6 @@ import os
 import ipdb
 import numpy as np
 import h5py
-from fnmatch import fnmatch
 from shutil import copyfile
 from astropy.table import Table, Column
 from astropy.utils.data import download_file
@@ -47,7 +46,7 @@ def get_remote_models(model_grid_name):
 
     """
     # update if zeonodo repository updated
-    repository = 4574453
+    repository = 4776833
 
     fname_dld_outputs = download_file(
         "https://zenodo.org/record/"

--- a/desk/set_up/scale_external.py
+++ b/desk/set_up/scale_external.py
@@ -1,18 +1,24 @@
+import ipdb
 import numpy as np
+from fnmatch import fnmatch
 from astropy.table import Column, Table
 
 
-def scale_by_distance(_outputs, _models, scaling_factor):
+def scale_by_distance(_grid_name, _outputs, _models, scaling_factor, distance):
     """Scale external model fluxes and normalization value.
 
     Parameters
     ----------
+    _grid_name : str
+        name of grid specified
     _outputs : astropy table
         grid outputs.
     _models : astropy table
         grid models.
     scaling_factor : float
         Scaling factor to scale grids to distance.
+    distance :
+        distance in kpc
 
     Returns
     -------
@@ -22,18 +28,35 @@ def scale_by_distance(_outputs, _models, scaling_factor):
         astropy table with sclaed fluxes
 
     """
-    # get log normalization for model
-    _outputs["norm"] = np.log10(_outputs["norm"] / scaling_factor * _outputs["lum"])
 
-    # scale grid_fluxes
-    scaled_models = []
     print("Scaling model grid by distance (" + str(len(_models)) + " models)")
 
-    for i, lum_val in enumerate(_outputs["lum"]):
-        scaled_flux_array = np.multiply(
-            _models["flux_wm2"][i], lum_val / scaling_factor
+    if fnmatch(_grid_name, "grams*"):
+        # Norm is the log normalization for plotting GRAMS
+        _outputs["norm"] = np.log10(
+            _outputs["norm"] * np.square(50) / np.square(distance)
         )
-        scaled_models.append(scaled_flux_array)
+        scaled_models = _models["flux_wm2"] * np.power(10, _outputs["norm"][0])
+        if (distance < 20) | (distance > 150):
+            print(
+                "\n"
+                + "=" * 75
+                + "\nWARNING:\n"
+                + "\nThis is beyond the suggested range (20-150 kpc) "
+                + "for using the GRAMS grids.\n"
+                + "This may result in unrealistic geometries.\n\n"
+                + "=" * 75
+            )
+
+    else:
+        # Norm is the log normalization for plotting Nanni et al. models
+        _outputs["norm"] = np.log10(_outputs["norm"] / scaling_factor * _outputs["lum"])
+        scaled_models = []
+        for i, lum_val in enumerate(_outputs["lum"]):
+            scaled_flux_array = np.multiply(
+                _models["flux_wm2"][i], lum_val / scaling_factor
+            )
+            scaled_models.append(scaled_flux_array)
 
     full_models = Table(
         (_models["wavelength_um"], Column(scaled_models, name="flux_wm2"))

--- a/desk/set_up/scale_external.py
+++ b/desk/set_up/scale_external.py
@@ -1,4 +1,3 @@
-import ipdb
 import numpy as np
 from fnmatch import fnmatch
 from astropy.table import Column, Table

--- a/docs/grids.rst
+++ b/docs/grids.rst
@@ -139,7 +139,7 @@ code for the LMC metallicity (1/2 solar) using optical constants from
 .. _Elitzur & Ivezić 2001: https://ui.adsabs.harvard.edu/abs/2001MNRAS.327..403E/abstract
 .. _Sargent et al. (2011): https://ui.adsabs.harvard.edu/abs/2011ApJ...728...93S/abstract
 .. _Srinivasan et al. (2011): https://ui.adsabs.harvard.edu/abs/2011A%26A...532A..54S/abstract
-.. _2DUST: https://2dust.stsci.edu/index.cgi
+.. _2DUST: https://ui.adsabs.harvard.edu/abs/2003ApJ...586.1338U/abstract
 .. _Zubko et al. (1996): https://ui.adsabs.harvard.edu/abs/1996MNRAS.282.1321Z/abstract
 .. _Ossenkopf et al. (1992): https://ui.adsabs.harvard.edu/abs/1992A%26A...261..567O/abstract
 .. _Aringer et al. (2016): https://ui.adsabs.harvard.edu/abs/2016MNRAS.457.3611A/abstract

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -83,12 +83,24 @@ Outputs
 	:alt: SED example
 
 This is an example of the output_sed.png file fitting three massive oxygen-rich
-AGB stars from the LMC. To produce individual figures subsequently run the command:
+AGB stars from the LMC created using
+
+.. code-block:: console
+
+	> desk sed
+
+To produce individual figures subsequently run the command:
 
 .. code-block:: console
 
 	> desk sed_indiv
 
+Additionally you can specify whether you want the output flux in the figure to
+be in W/m2 or Jy (W/m2 is the default).
+
+.. code-block:: console
+
+	> desk sed --flux='Jy'
 
 Use in Python Environment
 -------------------------
@@ -108,6 +120,7 @@ One can also use the sed, save_model, and grids in a similar fashion.
 .. code-block:: console
 
 	>>> sed()
+	>>> sed(flux='Jy')
 	>>> grids()
 	>>> save_model("Oss-Orich-bb", 10000, 2700, 1000, 0.4, 50)
 	>>> save_model(grid_name="Oss-Orich-bb", luminosity=10000, teff=2700, tinner=1000, tau=0.4, distance_in_kpc=50)

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,6 @@ setup(
     test_suite="tests",
     tests_require=["pytest", "sphinx_automodapi"],
     url="https://github.com/s-goldman/Dusty_Evolved_Star_Kit",
-    version="1.8.2",
+    version="1.8.3",
     zip_safe=False,
 )


### PR DESCRIPTION
Added distance and grid_name to scale_by_distance function in scale_external.py. Also fixed the scaling for GRAMS. Previously the model grids were scaling by the shape of the model and the specified luminosity, as the scaling is done for the DUSTY and Nanni et al. models. Now the GRAMS models scale by a similar norm factor but that is calculated differently for GRAMS and the nanni et al. models. For GRAMS we now use norm as: 

50^2 / distance ^ 2

also updated GRAMS models to be in wm2 instead of Jy.
also added warning for GRAMS usage outside of specified range. #191 
also updated broken 2DUST and GRAMS links. #189 