### PR TITLE
Reactivating codecov

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -11,3 +11,6 @@ dependencies:
     - sphinx-astropy
     - sphinx_automodapi
     - Pillow
+
+- name: Codecov
+  uses: codecov/codecov-action@v3.1.1


### PR DESCRIPTION
Codecov was deactivated for some reason. Added action to github actions (.yml file) in order to try and re-initialize automatic code coverage. 