### PR TITLE
Skipping vizier_sed test

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -24,3 +24,5 @@ jobs:
         - macos: py311
         - linux: py312
         - macos: py312
+        - linux: py313
+        - macos: py313

--- a/desk/tests/test_console_commands.py
+++ b/desk/tests/test_console_commands.py
@@ -159,7 +159,7 @@ def test_single_fit_options(tmpdir):
         testing=True,
     )
 
-
+@pytest.mark.skip(reason="Simultaneous calls fail to connect to the Vizier server when run with github actions.")
 @pytest.mark.parametrize(
     "target_name", ["MSX LMC 807", (295.4879586347, 16.7446716483)]
 )


### PR DESCRIPTION
The test regularly failed to connect to the cds server. I'm guessing this has to do with the flurry of calls at the same time. This will become a test that is run occasionally at the command line and not using github actions. 